### PR TITLE
feat: `ignoreMissing` translate option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,8 @@ cache:
     - ~/.npm
 before_install:
   - npm install -g npm
-  - npm install -g nsp
 install:
   - travis_retry npm install
-before_script:
-  - nsp check
 after_script: null
 after_success:
   - cat ./coverage/lcov.info | ./node_modules/.bin/coveralls

--- a/src/I18nProvider.tsx
+++ b/src/I18nProvider.tsx
@@ -13,22 +13,25 @@ const FALLBACK_LANGUAGE = 'en';
  * @param params - a map of strings to values.  For example, if 'name' is provided as a key of `params`,
  *   then '{name}' in the translated string will be replaced with the value in `params.name`.
  * @param language - language to translate into.
+ * @param [ignoreMissing] - enable this flag to prevent showing an error when the
+ *   translation is missing in target and fallback languages (returns nothing instead).
  * @returns translated string.
  */
-export function defaultTranslate({ translations, message, params, language } : {
-    translations: { [locale: string] : { [message: string]: string } };
-    message: string | { [locale: string] : string };
+export function defaultTranslate({ translations, message, params, language, ignoreMissing }: {
+    translations: { [locale: string]: { [message: string]: string } };
+    message: string | { [locale: string]: string };
     params: { [key: string]: string };
     language: string;
-}) : string {
+    ignoreMissing?: boolean;
+}): string {
     let translation: string;
-    if(typeof(message) === 'string') {
+    if(typeof (message) === 'string') {
         translation = (translations[language] && translations[language][message]) ||
             (translations[FALLBACK_LANGUAGE] && translations[FALLBACK_LANGUAGE][message]);
     } else {
-        translation = message[language] || message[FALLBACK_LANGUAGE];
+        translation = message[language] || (message[FALLBACK_LANGUAGE]);
     }
-    translation = translation || `Untranslated string: ${message}`;
+    translation = translation || (!ignoreMissing && `Untranslated string: ${message}`) || '';
 
     if(params) {
         Object.keys(params).forEach(sub => {
@@ -49,7 +52,7 @@ export function defaultTranslate({ translations, message, params, language } : {
  * where `translations` is an object where keys are languages (e.g. 'en', 'fr', etc...) and each value is a hash
  * of keys to translated strings.
  */
-export default function I18nProvider(props : {
+export default function I18nProvider(props: {
     language: string;
     translations: any;
     noEscape?: boolean;
@@ -61,14 +64,14 @@ export default function I18nProvider(props : {
     return <I18nContext.Provider value={{
         language: props.language,
         noEscape: props.noEscape || false,
-        translate: (message, params) => {
-            if(!message) { return "react-i18n-wrapper: No message supplied."; }
-            return translate({
+        translate: (message:any, params:any, options?:any) => {
+            if (!message) { return "react-i18n-wrapper: No message supplied."; }
+            return translate(Object.assign({}, options || {}, {
                 translations: props.translations,
                 language: props.language,
                 message,
                 params
-            });
+            }));
         }
     }}>
         { props.children }

--- a/src/I18nProvider.tsx
+++ b/src/I18nProvider.tsx
@@ -25,11 +25,11 @@ export function defaultTranslate({ translations, message, params, language, igno
     ignoreMissing?: boolean;
 }): string {
     let translation: string;
-    if(typeof (message) === 'string') {
+    if(typeof(message) === 'string') {
         translation = (translations[language] && translations[language][message]) ||
             (translations[FALLBACK_LANGUAGE] && translations[FALLBACK_LANGUAGE][message]);
     } else {
-        translation = message[language] || (message[FALLBACK_LANGUAGE]);
+        translation = message[language] || message[FALLBACK_LANGUAGE];
     }
     translation = translation || (!ignoreMissing && `Untranslated string: ${message}`) || '';
 
@@ -65,7 +65,7 @@ export default function I18nProvider(props: {
         language: props.language,
         noEscape: props.noEscape || false,
         translate: (message:any, params:any, options?:any) => {
-            if (!message) { return "react-i18n-wrapper: No message supplied."; }
+            if(!message) { return "react-i18n-wrapper: No message supplied."; }
             return translate(Object.assign({}, options || {}, {
                 translations: props.translations,
                 language: props.language,

--- a/src/Translate.tsx
+++ b/src/Translate.tsx
@@ -12,16 +12,17 @@ export default function Translate(props : {
     noEscape?: boolean;
     typeName?: string;
     tagName?: string;
+    ignoreMissing?: boolean;
     [key: string]: any;
 }) {
     return <I18nContext.Consumer>{
         i18n => {
             if(!i18n) {throw new Error("I18nProvider required");}
 
-            const { message, params, noEscape, typeName, tagName, ...childProps } = props;
+            const { message, params, noEscape, typeName, tagName, ignoreMissing, ...childProps } = props;
 
             const tagType = tagName || typeName || undefined;
-            const translated = i18n.translate(props.message, props.params || {});
+            const translated = i18n.translate(props.message, props.params || {}, { ignoreMissing });
 
             if(isUndefined(props.noEscape) ? i18n.noEscape : props.noEscape) {
                 return React.createElement(tagType || 'span',

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ export interface TranslationFunctionParams {
     translations: any;
     message: any;
     params: any;
+    ignoreMissing?: boolean;
 }
 export type TranslateFunction = (params: TranslationFunctionParams) => string;
 
@@ -16,7 +17,7 @@ export interface I18nContextType {
      *   will be replaced with the value in `params.name`.
      * @returns the translated string.
      */
-    translate: (message: any, params?: any) => string;
+    translate: (message: any, params?: any, options?: any) => string;
     language: string;
     noEscape: boolean;
 }


### PR DESCRIPTION
When `ignoreMissing` option is enabled on call to the translate function, a missing translation for a particular language will still fallback to english but, if english itself is missing, an empty string will be rendered instead of the "Untranslated string" error.